### PR TITLE
Pass the API key to get_customer_data() method in Notices and AdminBar

### DIFF
--- a/src/Admin/AdminBar/AdminBar.php
+++ b/src/Admin/AdminBar/AdminBar.php
@@ -57,10 +57,12 @@ class AdminBar {
 			return;
 		}
 
+		$api_key = $this->options->get( 'api_key', '' );
+
 		if (
-			empty( $this->options->get( 'api_key' ) )
+			empty( $api_key )
 			||
-			empty( $this->api_client->get_customer_data() )
+			empty( $this->api_client->get_customer_data( $api_key ) )
 		) {
 			$wp_admin_bar->add_node(
 				[

--- a/src/Admin/Notices/Notices.php
+++ b/src/Admin/Notices/Notices.php
@@ -68,10 +68,12 @@ class Notices {
 			return;
 		}
 
+		$api_key = $this->options->get( 'api_key', '' );
+
 		if (
-			empty( $this->options->get( 'api_key' ) )
+			empty( $api_key )
 			||
-			! empty( $this->api_client->get_customer_data() )
+			! empty( $this->api_client->get_customer_data( $api_key ) )
 		) {
 			return;
 		}


### PR DESCRIPTION
### Issue:
- The `wrong api key` notice was displayed for a user even though the API key is correct. They had to remove the API key value and add it again to make the notice go away.

### Cause:
- We were not passing the API key value to `get_customer_data()` in this notice code. So that means if there was no cached data available (transient expired or not existant), we were trying to get the data from the source, but without passing an API key value. The returned value was an empty array instead of the expected customer data.

### Solution:
- Make sure to pass the API key value from the options in this context, so that if we have no cached data, it will revalidate from the source correctly.
- Do the same in the AdminBar code, to make sure the correct admin bar menu items are displayed (not initially reported, but looking at the code it's the same logic).