### PR TITLE
Use hostname instead of URL to compare against the API response

### DIFF
--- a/src/API/Client.php
+++ b/src/API/Client.php
@@ -98,14 +98,14 @@ class Client {
 			return false;
 		}
 
-		$home_url = home_url();
+		$hostname = $this->extract_hostname( home_url() );
 
 		foreach ( $customer_data['websites'] as $website ) {
-			if ( ! isset( $website['url'] ) ) {
+			if ( ! isset( $website['hostname'] ) ) {
 				continue;
 			}
 
-			if ( $home_url === $website['url'] ) {
+			if ( $hostname === $website['hostname'] ) {
 				return true;
 			}
 		}
@@ -125,14 +125,14 @@ class Client {
 			return '';
 		}
 
-		$home_url = home_url();
+		$hostname = $this->extract_hostname( home_url() );
 
 		foreach ( $customer_data['websites'] as $website ) {
-			if ( ! isset( $website['url'] ) ) {
+			if ( ! isset( $website['hostname'] ) ) {
 				continue;
 			}
 
-			if ( $home_url !== $website['url'] ) {
+			if ( $hostname !== $website['hostname'] ) {
 				continue;
 			}
 
@@ -213,5 +213,35 @@ class Client {
 		 * @param string $api_url API URL.
 		 */
 		return apply_filters( 'rocketcdn_base_api_url', self::ROCKETCDN_API );
+	}
+
+	/**
+	 * Extracts the hostname (host + path if set) from the URL
+	 *
+	 * @param string $url URL to parse.
+	 *
+	 * @return string
+	 */
+	private function extract_hostname( string $url ): string {
+		$parsed_url = wp_parse_url( $url );
+		$path       = '';
+
+		if ( ! $parsed_url ) {
+			return '';
+		}
+
+		if ( empty( $parsed_url['host'] ) ) {
+			return '';
+		}
+
+		if (
+			! empty( $parsed_url['path'] )
+			&&
+			'/' !== $parsed_url['path']
+		) {
+			$path = $parsed_url['path'];
+		}
+
+		return $parsed_url['host'] . $path;
 	}
 }

--- a/src/API/Client.php
+++ b/src/API/Client.php
@@ -216,32 +216,19 @@ class Client {
 	}
 
 	/**
-	 * Extracts the hostname (host + path if set) from the URL
+	 * Extracts the hostname from the URL
 	 *
 	 * @param string $url URL to parse.
 	 *
 	 * @return string
 	 */
 	private function extract_hostname( string $url ): string {
-		$parsed_url = wp_parse_url( $url );
-		$path       = '';
+		$host = wp_parse_url( $url, PHP_URL_HOST );
 
-		if ( ! $parsed_url ) {
+		if ( empty( $host ) ) {
 			return '';
 		}
 
-		if ( empty( $parsed_url['host'] ) ) {
-			return '';
-		}
-
-		if (
-			! empty( $parsed_url['path'] )
-			&&
-			'/' !== $parsed_url['path']
-		) {
-			$path = $parsed_url['path'];
-		}
-
-		return $parsed_url['host'] . $path;
+		return $host;
 	}
 }


### PR DESCRIPTION
### Issue
Some websites were not validating correctly when adding the API key, returning the error message that the website is not sync, even though it is in the RocketCDN account.

### Root cause
This was happening because when checking the API response to see if the website was correctly linked to the account, we were exactly comparing the full URL in the API result against the full URL in the WP home URL setting.

Those can be not the same, i.e. URL in RocketCDN account is `http://example.org/` and URL in WP is `http://example.org`. Note the trailing slash difference. This could also happen with the protocol (http vs https).

### Solution
To avoid this issue, the API also returns an `hostname` value, with no trailing slash and no protocol. We then use this value and the extracted hostname value from the WP home URL to do the comparison instead.