### PR TITLE
Exclude admin_url in srcset from being rewritten

### DIFF
--- a/src/Front/CDN.php
+++ b/src/Front/CDN.php
@@ -113,6 +113,10 @@ class CDN {
 			return $html;
 		}
 		foreach ( $srcsets as $srcset ) {
+			if ( stristr( $srcset[0], admin_url() ) ) {
+				continue;
+			}
+
 			$sources    = explode( ',', $srcset['sources'] );
 			$sources    = array_unique( array_map( 'trim', $sources ) );
 			$cdn_srcset = $srcset['sources'];


### PR DESCRIPTION
Here we need to exclude admin_url in srcset from being rewritten by the CDN url not to cause the logout problem