### PR TITLE
Closes Imagify #891 Adjust priority for template_redirect filter

### DIFF
--- a/src/Front/Subscriber.php
+++ b/src/Front/Subscriber.php
@@ -29,7 +29,7 @@ class Subscriber implements SubscriberInterface {
 	 */
 	public static function get_subscribed_events() {
 		return [
-			'template_redirect' => [ 'start_buffering', 2 ],
+			'template_redirect' => [ 'start_buffering', 5 ],
 			'wp_resource_hints' => [ 'add_preconnect_cdn', 10, 2 ],
 		];
 	}


### PR DESCRIPTION
# Description

Fixes https://github.com/wp-media/imagify-plugin/issues/891


## Type of change
- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario
Check this comment https://github.com/wp-media/imagify-plugin/pull/893#issuecomment-2298451180

## Technical description
Change the `template_redirect` priority

### Documentation
Change the `template_redirect` priority to solve edge-cases when other plugins are active.


# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.